### PR TITLE
 TPP-00009: Blank Settings Page #9 

### DIFF
--- a/tpp-app/package.json
+++ b/tpp-app/package.json
@@ -15,13 +15,13 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "~0.63.4",
+    "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
+    "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-unimodules": "~0.14.5",
-    "react-native-web": "~0.13.12",
-    "react-native-safe-area-context": "3.2.0"
-
+    "react-native-web": "~0.13.12"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/tpp-app/package.json
+++ b/tpp-app/package.json
@@ -19,7 +19,9 @@
     "react-native-reanimated": "~2.2.0",
     "react-native-screens": "~3.4.0",
     "react-native-unimodules": "~0.14.5",
-    "react-native-web": "~0.13.12"
+    "react-native-web": "~0.13.12",
+    "react-native-safe-area-context": "3.2.0"
+
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/tpp-app/src/settings/Settings.js
+++ b/tpp-app/src/settings/Settings.js
@@ -1,10 +1,18 @@
-import React from 'react';
-import { Text, View } from 'react-native';
+import React, {useState} from 'react';
+import {View, Switch } from 'react-native';
+import {Card} from 'react-native-elements';
 
 export default function Settings () {
+    const [isEnabled, setIsEnabled] = useState(true)
+    const toggleSwitch = () => setIsEnabled(previousState => !previousState);
     return (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-            <Text>Settings!</Text>
+            <Card>
+                <Switch
+                    onValueChange={toggleSwitch}
+                    value={isEnabled}
+                />
+            </Card>
         </View>
     )
 }


### PR DESCRIPTION
# Description

Added a blank switch on a card on the Settings page

Installed `react-native-elements` and `react-native-safe-area-context`

Fixes #9 
![image](https://user-images.githubusercontent.com/22108651/141218752-c962f420-3478-4c88-b246-f316a1cfdc33.png)


## Type of change


- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works