### PR TITLE
Resolve Cycle cards temporarily showing old values + flexible margins when showing tip

### DIFF
--- a/tpp-app/src/home/components/CycleCard.js
+++ b/tpp-app/src/home/components/CycleCard.js
@@ -51,9 +51,10 @@ import {View, Text, StyleSheet} from 'react-native';
  )
  }
 
- export default function CycleCard({periodDays, daysSinceLastPeriod, cycleDonutPercent}){
+ export default function CycleCard({periodDays, daysSinceLastPeriod, cycleDonutPercent, showTip}){
+   let styleWithTip = showTip ? {} : styles.noTip;
    return (
-        <View style={[styles.card]}>
+        <View style={[styles.card, styleWithTip]}>
           <Cycle periodDays={periodDays} daysSinceLastPeriod={daysSinceLastPeriod} cycleDonutPercent={cycleDonutPercent}/>
         </View>
    );
@@ -64,6 +65,9 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     height: 298,
     backgroundColor: "white",
+  },
+  noTip: {
+    marginTop: 50
   },
   cycleText: {
     fontFamily: "Avenir",

--- a/tpp-app/src/home/components/CycleCard.js
+++ b/tpp-app/src/home/components/CycleCard.js
@@ -52,9 +52,8 @@ import {View, Text, StyleSheet} from 'react-native';
  }
 
  export default function CycleCard({periodDays, daysSinceLastPeriod, cycleDonutPercent, showTip}){
-   let styleWithTip = showTip ? {} : styles.noTip;
    return (
-        <View style={[styles.card, styleWithTip]}>
+        <View style={[styles.card, !showTip && styles.noTip]}>
           <Cycle periodDays={periodDays} daysSinceLastPeriod={daysSinceLastPeriod} cycleDonutPercent={cycleDonutPercent}/>
         </View>
    );

--- a/tpp-app/src/home/pages/CycleHistoryScreen.js
+++ b/tpp-app/src/home/pages/CycleHistoryScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {SafeAreaView, Text, StyleSheet, View, TouchableOpacity, ImageBackground} from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import background from '../../../ios/tppapp/Images.xcassets/SplashScreenBackground.imageset/watercolor-background.png';
@@ -57,7 +57,7 @@ export default function CycleHistoryScreen({navigation}){
     let [onPeriod, setOnPeriod] = useState(DEFAULTS.ON_PERIOD);
     
     useFocusEffect(
-        React.useCallback(() => {
+        useCallback(() => {
         GETStoredYears().then(
             years => {
                 setStoredYears(years);
@@ -72,7 +72,7 @@ export default function CycleHistoryScreen({navigation}){
 
     //get intervals for all stored years
     useFocusEffect(
-        React.useCallback(
+        useCallback(
         () => {
         async function storeYearsCycles() {
             for (const year of storedYears){
@@ -80,7 +80,6 @@ export default function CycleHistoryScreen({navigation}){
                 currentIntervals[year] = intervals;
             }
             setCurrentIntervals({...currentIntervals});
-            console.log(currentIntervals);
         }
         storeYearsCycles();
     }, [storedYears]));

--- a/tpp-app/src/home/pages/CycleHistoryScreen.js
+++ b/tpp-app/src/home/pages/CycleHistoryScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {SafeAreaView, Text, StyleSheet, View, TouchableOpacity, ImageBackground} from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import background from '../../../ios/tppapp/Images.xcassets/SplashScreenBackground.imageset/watercolor-background.png';
@@ -6,6 +6,7 @@ import {ExpandedHistoryCard} from '../components/CycleHistory';
 import CycleService from '../../services/cycle/CycleService';
 import {GETStoredYears} from '../../services/utils/helpers';
 import {useFocusEffect} from '@react-navigation/native';
+import { set } from 'date-fns';
 
 function Header({navigation}){
     return(
@@ -41,20 +42,22 @@ function YearButton({year, selectedYear, setSelectedYear}){
 }
 
 export default function CycleHistoryScreen({navigation}){
+    let currentYear = new Date().getFullYear();
+    let intervalsDefault = {};
+    intervalsDefault[currentYear] = []
     const DEFAULTS = {
-        CURRENT_INTERVALS: [],
+        INTERVALS: intervalsDefault,
         STORED_YEARS: [],
         ON_PERIOD: false
     }
 
-    let [currentIntervals, setCurrentIntervals] = useState(DEFAULTS.CURRENT_INTERVALS);
-    let [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+    let [currentIntervals, setCurrentIntervals] = useState(DEFAULTS.INTERVALS);
+    let [selectedYear, setSelectedYear] = useState(currentYear);
     let [storedYears, setStoredYears] = useState(DEFAULTS.STORED_YEARS);
     let [onPeriod, setOnPeriod] = useState(DEFAULTS.ON_PERIOD);
     
     useFocusEffect(
         React.useCallback(() => {
-        console.log("on focus for startup")
         GETStoredYears().then(
             years => {
                 setStoredYears(years);
@@ -67,18 +70,20 @@ export default function CycleHistoryScreen({navigation}){
         .catch(() => setOnPeriod(DEFAULTS.ON_PERIOD))
     }, []));
 
-    //update the cycles being rendered to reflect newly selected year.
+    //get intervals for all stored years
     useFocusEffect(
-        React.useCallback(() => {
-            console.log("on focus for intervalss")
-            CycleService.GETCycleHistoryByYear(selectedYear).then(
-                intervals => {
-                    setCurrentIntervals(intervals);
-                }
-            )
-            .catch(() => setCurrentIntervals(DEFAULTS.CURRENT_INTERVALS)) //error case, render empty card
+        React.useCallback(
+        () => {
+        async function storeYearsCycles() {
+            for (const year of storedYears){
+                intervals = await CycleService.GETCycleHistoryByYear(year)            
+                currentIntervals[year] = intervals;
+            }
+            setCurrentIntervals({...currentIntervals});
+            console.log(currentIntervals);
         }
-    ,[selectedYear]));
+        storeYearsCycles();
+    }, [storedYears]));
 
     return (
         <SafeAreaView style={styles.container}>
@@ -90,7 +95,7 @@ export default function CycleHistoryScreen({navigation}){
                     </View>
                     <ExpandedHistoryCard 
                         navigation={navigation} 
-                        intervals={currentIntervals} 
+                        intervals={currentIntervals[selectedYear]} 
                         renderedYear={selectedYear}
                         onPeriod={onPeriod}
                     />

--- a/tpp-app/src/home/pages/CycleScreen.js
+++ b/tpp-app/src/home/pages/CycleScreen.js
@@ -93,7 +93,6 @@ export default function CycleScreen ({navigation}){
         setAvgCycleLength(numDays);
        }
        else {
-         console.log("defaulting average cycle length");
          setAvgCycleLength(DEFAULTS.AVG_CYCLE_LENGTH);
        }
      })
@@ -130,7 +129,6 @@ export default function CycleScreen ({navigation}){
   const tipInvisibleStyle = {
     marginBottom: tabBarHeight
   }
-  console.log(showTip)
   const cardContainerStyle = showTip ? styles.cardContainer : Object.assign({}, styles.cardContainer, tipInvisibleStyle);
   return (
     <SafeAreaView style={styles.container}>

--- a/tpp-app/src/home/pages/CycleScreen.js
+++ b/tpp-app/src/home/pages/CycleScreen.js
@@ -107,6 +107,7 @@ export default function CycleScreen ({navigation}){
        else{
          toSet = DEFAULTS.DAYS_TILL_PERIOD;
          //if the prediction is invalid, don't show the tooltip
+         //will not show tip until average cycle is computed
          setShowTip(false);
        }
        setDaysTillPeriod(toSet);
@@ -129,7 +130,7 @@ export default function CycleScreen ({navigation}){
   const tipInvisibleStyle = {
     marginBottom: tabBarHeight
   }
-
+  console.log(showTip)
   const cardContainerStyle = showTip ? styles.cardContainer : Object.assign({}, styles.cardContainer, tipInvisibleStyle);
   return (
     <SafeAreaView style={styles.container}>
@@ -146,6 +147,7 @@ export default function CycleScreen ({navigation}){
             periodDays={periodDays} 
             daysSinceLastPeriod={daysSinceLastPeriod} 
             cycleDonutPercent={cycleDonutPercent}
+            showTip={showTip}
           />
           <SafeAreaView style={[styles.rowContainer, styles.infoCardContainer, styles.element]}>
             <InfoCard header="Average period length" days={avgPeriodLength} backgroundColor="#FFDBDB">


### PR DESCRIPTION
# Description
See: https://uoftblueprint.slack.com/files/U027U9EVCCQ/F03AS36EE77/image_from_ios.mov

When user has multiple years logged and is on Period History Card (See below), and switches years, the card will retain it's old values for a few seconds before updating.

<img width="316" alt="image" src="https://user-images.githubusercontent.com/22108651/162581049-ab49e78e-1ced-409b-9c3d-9d6446cfbbfb.png">


Also changed so the margin from the Donut Card to the top changes depending on whether the tip about impending period shows or not.

When no tip:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/22108651/162594101-bb455132-9bd0-43e9-9b61-bbe30528d639.png">

When tip:
Unchanged from PR for issue 91

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
