### PR TITLE
Fixed mutiselect for uninitialied years

### DIFF
--- a/tpp-app/src/services/LogSymptomsService.js
+++ b/tpp-app/src/services/LogSymptomsService.js
@@ -55,7 +55,7 @@ export const POSTsymptomsForDate = async (day, month, year, symptoms) => new Pro
  * date.month is a number (January = 1),
  * date.year is a number.
  */
-export const LogMultipleDayPeriod = async (dates) => new Promise(async (resolve, reject) => {
+export const LogMultipleDayPeriod = async (dates) => {
     // run this code for each value in the dates array
     if(dates.length > 0){
         try {
@@ -68,6 +68,11 @@ export const LogMultipleDayPeriod = async (dates) => new Promise(async (resolve,
                 const month = date.month;
                 const day = date.day;
                 try {
+
+                    // initialize years that are not in the data
+                    if(!calendarData[year]){
+                        calendarData[year] = initializeEmptyYear(year);
+                    }
                     
                     let symptoms = getSymptomsFromCalendar(calendarData, day, month, year);
 
@@ -84,41 +89,52 @@ export const LogMultipleDayPeriod = async (dates) => new Promise(async (resolve,
 
             })
 
-            if(calendarData[curYear]){
-                AsyncStorage.setItem(curYear.toString(), JSON.stringify(calendarData[curYear]))
-                .then(() => resolve())
-                .catch((e) => {
-                    console.log(JSON.stringify(e));
-                    reject(`Unable to mergeItem and post symptoms for multiselect.`);
-                });
-                
-            }
-            
-            if(calendarData[curYear - 1]){
-                AsyncStorage.setItem((curYear - 1).toString(), JSON.stringify(calendarData[curYear - 1]))
-                .then(() => resolve())
-                .catch((e) => {
-                    reject(`Unable to mergeItem and post symptoms for multiselect.`);
-                    console.log(JSON.stringify(e));
-                });
+            for (const [key, value] of Object.entries(calendarData)){
+                // console.log(key, value);
+                if(value){
+                    try {
+                        await AsyncStorage.setItem(key.toString(), JSON.stringify(value));
+                    } catch (error) {
+                        console.log(`LogMultipleDayPeriod error: ${JSON.stringify(error)}`)
+                    }
+                }
             }
 
-            // a bit unneccessary since you can't log symptoms for the future.
-            if(calendarData[curYear + 1]){
-                AsyncStorage.setItem((curYear + 1).toString(), JSON.stringify(calendarData[curYear + 1]))
-                .then(() => resolve())
-                .catch((e) => {
-                    reject(`Unable to mergeItem and post symptoms for multiselect.`);
-                    console.log(JSON.stringify(e));
-                });
-            }
+            // if(calendarData[curYear]){
+            //     AsyncStorage.setItem(curYear.toString(), JSON.stringify(calendarData[curYear]))
+            //     .then(() => resolve())
+            //     .catch((e) => {
+            //         console.log(JSON.stringify(e));
+            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
+            //     });
+                
+            // }
+            
+            // if(calendarData[curYear - 1]){
+            //     AsyncStorage.setItem((curYear - 1).toString(), JSON.stringify(calendarData[curYear - 1]))
+            //     .then(() => resolve())
+            //     .catch((e) => {
+            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
+            //         console.log(JSON.stringify(e));
+            //     });
+            // }
+
+            // // a bit unneccessary since you can't log symptoms for the future.
+            // if(calendarData[curYear + 1]){
+            //     AsyncStorage.setItem((curYear + 1).toString(), JSON.stringify(calendarData[curYear + 1]))
+            //     .then(() => resolve())
+            //     .catch((e) => {
+            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
+            //         console.log(JSON.stringify(e));
+            //     });
+            // }
 
         } catch (error) {
             console.log("error with multiselect:",error);
         }
     }
 
-})
+}
 
 // TODO implement helper function
 const postSymptomsForYear = async (calendarData, year) => {

--- a/tpp-app/src/services/LogSymptomsService.js
+++ b/tpp-app/src/services/LogSymptomsService.js
@@ -76,8 +76,6 @@ export const LogMultipleDayPeriod = async (dates) => {
                     
                     let symptoms = getSymptomsFromCalendar(calendarData, day, month, year);
 
-                    // console.log(symptoms);
-
                     if (symptoms.flow == null || symptoms.flow == FLOW_LEVEL.NONE){
                         symptoms.flow = FLOW_LEVEL.MEDIUM;
                     }
@@ -90,7 +88,7 @@ export const LogMultipleDayPeriod = async (dates) => {
             })
 
             for (const [key, value] of Object.entries(calendarData)){
-                // console.log(key, value);
+
                 if(value){
                     try {
                         await AsyncStorage.setItem(key.toString(), JSON.stringify(value));
@@ -99,35 +97,6 @@ export const LogMultipleDayPeriod = async (dates) => {
                     }
                 }
             }
-
-            // if(calendarData[curYear]){
-            //     AsyncStorage.setItem(curYear.toString(), JSON.stringify(calendarData[curYear]))
-            //     .then(() => resolve())
-            //     .catch((e) => {
-            //         console.log(JSON.stringify(e));
-            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
-            //     });
-                
-            // }
-            
-            // if(calendarData[curYear - 1]){
-            //     AsyncStorage.setItem((curYear - 1).toString(), JSON.stringify(calendarData[curYear - 1]))
-            //     .then(() => resolve())
-            //     .catch((e) => {
-            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
-            //         console.log(JSON.stringify(e));
-            //     });
-            // }
-
-            // // a bit unneccessary since you can't log symptoms for the future.
-            // if(calendarData[curYear + 1]){
-            //     AsyncStorage.setItem((curYear + 1).toString(), JSON.stringify(calendarData[curYear + 1]))
-            //     .then(() => resolve())
-            //     .catch((e) => {
-            //         reject(`Unable to mergeItem and post symptoms for multiselect.`);
-            //         console.log(JSON.stringify(e));
-            //     });
-            // }
 
         } catch (error) {
             console.log("error with multiselect:",error);


### PR DESCRIPTION
# Description

Fixed bug where a selected date that is in an uninitialized year would cause an error. Now, LogMulitpleDayPeriod() will first initialize an empty year in those cases.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
