### PR TITLE
Scroll Fix

### DIFF
--- a/tpp-app/src/home/components/CycleCard.js
+++ b/tpp-app/src/home/components/CycleCard.js
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
     backgroundColor: "white",
   },
   noTip: {
-    marginTop: 50
+    marginTop: "7%"
   },
   cycleText: {
     fontFamily: "Avenir",

--- a/tpp-app/src/home/pages/CycleScreen.js
+++ b/tpp-app/src/home/pages/CycleScreen.js
@@ -139,7 +139,7 @@ export default function CycleScreen ({navigation}){
         {/* View that contains all the relevant cards */}
         <ScrollView>
           {/* Period Notification (Period in X days) */}
-          <View style={cardContainerStyle}>
+          <SafeAreaView style={cardContainerStyle}>
             {showTip && (
             <PeriodNotification daysTillPeriod={daysTillPeriod}>
               <Paddy style={styles.paddyIcon}/>
@@ -164,7 +164,7 @@ export default function CycleScreen ({navigation}){
               intervals={intervals}
               onPeriod={periodDays !=0}
             />
-          </View>
+          </SafeAreaView>
 
         </ScrollView>
       </ImageBackground>

--- a/tpp-app/src/home/pages/CycleScreen.js
+++ b/tpp-app/src/home/pages/CycleScreen.js
@@ -107,7 +107,7 @@ export default function CycleScreen ({navigation}){
          toSet = DEFAULTS.DAYS_TILL_PERIOD;
          //if the prediction is invalid, don't show the tooltip
          //will not show tip until average cycle is computed
-         setShowTip(false);
+        //  setShowTip(false);
        }
        setDaysTillPeriod(toSet);
      })
@@ -129,37 +129,42 @@ export default function CycleScreen ({navigation}){
   const tipInvisibleStyle = {
     marginBottom: tabBarHeight
   }
-  const cardContainerStyle = showTip ? styles.cardContainer : Object.assign({}, styles.cardContainer, tipInvisibleStyle);
+  const tipVisibleStyle = {
+    marginBottom: 50
+  }
+  const cardContainerStyle = showTip ? Object.assign({}, styles.cardContainer, tipVisibleStyle) : Object.assign({}, styles.cardContainer, tipInvisibleStyle);
   return (
     <SafeAreaView style={styles.container}>
       <ImageBackground source={background} style={styles.container}>    
         {/* View that contains all the relevant cards */}
-        <ScrollView contentContainerStyle={cardContainerStyle}>
+        <ScrollView>
           {/* Period Notification (Period in X days) */}
-          {showTip && (
-          <PeriodNotification daysTillPeriod={daysTillPeriod}>
-            <Paddy style={styles.paddyIcon}/>
-          </PeriodNotification>
-          )}
-          <CycleCard 
-            periodDays={periodDays} 
-            daysSinceLastPeriod={daysSinceLastPeriod} 
-            cycleDonutPercent={cycleDonutPercent}
-            showTip={showTip}
-          />
-          <SafeAreaView style={[styles.rowContainer, styles.infoCardContainer, styles.element]}>
-            <InfoCard header="Average period length" days={avgPeriodLength} backgroundColor="#FFDBDB">
-              <BloodDrop fill="red" style={styles.icon}/>
-            </InfoCard>
-            <InfoCard header="Average cycle length" days={avgCycleLength} backgroundColor="#B9E0D8">
-              <Calendar fill="red" style={styles.icon}/>
-            </InfoCard>
-          </SafeAreaView>
-          <MinimizedHistoryCard 
-            navigation={navigation} 
-            intervals={intervals}
-            onPeriod={periodDays !=0}
-          />
+          <View style={cardContainerStyle}>
+            {showTip && (
+            <PeriodNotification daysTillPeriod={daysTillPeriod}>
+              <Paddy style={styles.paddyIcon}/>
+            </PeriodNotification>
+            )}
+            <CycleCard 
+              periodDays={periodDays} 
+              daysSinceLastPeriod={daysSinceLastPeriod} 
+              cycleDonutPercent={cycleDonutPercent}
+              showTip={showTip}
+            />
+            <SafeAreaView style={[styles.rowContainer, styles.infoCardContainer, styles.element]}>
+              <InfoCard header="Average period length" days={avgPeriodLength} backgroundColor="#FFDBDB">
+                <BloodDrop fill="red" style={styles.icon}/>
+              </InfoCard>
+              <InfoCard header="Average cycle length" days={avgCycleLength} backgroundColor="#B9E0D8">
+                <Calendar fill="red" style={styles.icon}/>
+              </InfoCard>
+            </SafeAreaView>
+            <MinimizedHistoryCard 
+              navigation={navigation} 
+              intervals={intervals}
+              onPeriod={periodDays !=0}
+            />
+          </View>
 
         </ScrollView>
       </ImageBackground>
@@ -178,8 +183,8 @@ const styles = StyleSheet.create({
       flex: 1,
       marginHorizontal: 16,
       alignItems: 'stretch',
-      justifyContent: 'space-evenly',
-  },  
+      paddingBottom: 50,
+  },
   rowContainer:{
     flexDirection: 'row',
     justifyContent: 'space-evenly',
@@ -255,6 +260,6 @@ const styles = StyleSheet.create({
     marginHorizontal: 10,
   },
   element: {
-    marginVertical: "15%"
+     marginVertical: "7%"
   }
 })


### PR DESCRIPTION
# Description

Before, the cycle screen was unable to scroll all the way to the bottom when the tip regarding when your next period is coming was shown. Now able to scroll all the way to the bottom.

Below is state described.
<img width="359" alt="image" src="https://user-images.githubusercontent.com/22108651/163491789-d506a4c6-82ad-484e-b7d7-291ab25af690.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings