### PR TITLE
added messages on no period/cycle length or no cycle + years in descending order

### DIFF
--- a/tpp-app/src/home/components/CycleHistory.js
+++ b/tpp-app/src/home/components/CycleHistory.js
@@ -5,6 +5,14 @@ import { CALENDAR_STACK_SCREENS } from '../CalendarNavigator';
 import { useNavigation } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
+const NothingLogged = () => {
+    return (
+    <Text style={styles.nothingLogged}>
+        Please start logging to learn more.
+    </Text>
+    )
+}
+
 const ShowMore = ({navigation}) => {
     return(
         <TouchableOpacity onPress={() => navigation.navigate(CALENDAR_STACK_SCREENS.CYCLE_HISTORY, {screen: CALENDAR_STACK_SCREENS.CYCLE_HISTORY})}>
@@ -16,7 +24,6 @@ const ShowMore = ({navigation}) => {
             </View>
         </TouchableOpacity>
     );
-
 }
 
 /**
@@ -68,6 +75,7 @@ function MinimizedHistoryCard({navigation, intervals, onPeriod}){
                     <Text style={styles.title}>Period History</Text>
                     <ShowMore navigation={navigation}/>
                 </SafeAreaView>
+                {(intervals.length == 0 ) && NothingLogged()}
                 {intervals.map((interval, index)=> {
                     if(index < 3){
                         return  <Interval 
@@ -96,6 +104,7 @@ function ExpandedHistoryCard({intervals, renderedYear, onPeriod}){
                 <View style={styles.bottomBorder}>
                     <Text style={styles.title}> {renderedYear} </Text>
                 </View>
+                {(intervals.length == 0 ) && NothingLogged()}
                 {intervals.map((interval, index) => {
                     return  <Interval 
                                 interval={interval} 
@@ -186,5 +195,14 @@ const styles = StyleSheet.create({
     },
     interval: {
         marginBottom: 19,
+    },
+    nothingLogged: {
+        fontFamily: "Avenir",
+        fontSize: 14,
+        fontWeight: "300",
+        lineHeight: 19,
+        letterSpacing: -0.30000001192092896,
+        textAlign: "left",
+        marginBottom: "10%"
     }
 })

--- a/tpp-app/src/home/pages/CycleHistoryScreen.js
+++ b/tpp-app/src/home/pages/CycleHistoryScreen.js
@@ -89,7 +89,7 @@ export default function CycleHistoryScreen({navigation}){
                 <Header navigation={navigation}/>
                 <SafeAreaView style={styles.cardContainer}>
                     <View style={styles.buttonContainer}>
-                        {storedYears.map((year, index) => <YearButton year={year} selectedYear={selectedYear} setSelectedYear={setSelectedYear} key={index}/>).reverse()}
+                        {storedYears.map((year, index) => <YearButton year={year} selectedYear={selectedYear} setSelectedYear={setSelectedYear} key={index}/>)}
                     </View>
                     <ExpandedHistoryCard 
                         navigation={navigation} 

--- a/tpp-app/src/home/pages/CycleScreen.js
+++ b/tpp-app/src/home/pages/CycleScreen.js
@@ -13,12 +13,13 @@ import Paddy from '../../../ios/tppapp/Images.xcassets/icons/paddy.svg';
 import { Footer } from '../../services/utils/footer';
 
 function InfoCard(props){
+  let DefaultText = <Text style={styles.messageForDefault}>Please start logging to learn more. </Text>;
   return (
     <View style={[styles.card, {backgroundColor: props.backgroundColor}]}>
       <View style={styles.infoCardInternal}>
         <Text style={styles.header}>{props.header}</Text>
-        <SafeAreaView style={[styles.rowContainer, styles.daysRow, {justifyContent: "space-between"}]}>
-          <Text style={styles.daysText}>{props.days} Days</Text>
+        <SafeAreaView style={[styles.infoCardRow, styles.daysRow]}>
+          {props.days === 0 ? DefaultText : <Text style={styles.daysText}>{props.days} Days</Text> }
           <SafeAreaView style={styles.whiteBackground}>
             {props.children}
           </SafeAreaView>
@@ -185,6 +186,17 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
     justifyContent: 'center'
   },
+  messageForDefault: {
+    fontFamily: "Avenir",
+    fontSize: 11,
+    fontWeight: "400",
+    lineHeight: 12,
+    letterSpacing: -0.30000001192092896,
+    textAlign: "left",
+    width: 70,
+    color: "#000000"
+  },
+
   cardContainer: {
       flex: 1,
       marginHorizontal: 16,
@@ -195,6 +207,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-evenly',
     alignItems: 'center'
+  },
+  infoCardRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   infoCardContainer:{
     justifyContent: 'space-between'
@@ -263,7 +280,8 @@ const styles = StyleSheet.create({
     transform: [{scale:0.4}]
   },
   infoCardInternal: {
-    marginHorizontal: 10,
+    marginLeft: "5%",
+    marginRight: "15%"
   },
   element: {
      marginVertical: "7%"


### PR DESCRIPTION
# Description


- added messages on no period/cycle length or no cycle
- when the average cycle length can't be computed, makes CycleDonutPercent default to a. value of 0
- Added reminder message for Cycle when there is no average cycle length or average period length
- years are now rendered in descending order

Cycle screen when no period/cycle length:

<img width="343" alt="image" src="https://user-images.githubusercontent.com/22108651/165392770-6a690fdd-f6c6-41e7-8994-cf2e51548ea9.png">

Period history screen when no period/cycle length:

<img width="324" alt="image" src="https://user-images.githubusercontent.com/22108651/165388496-12fb63fc-d639-465b-9a4a-79c3bb4c756a.png">

Period history Screen with descending years:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/22108651/165641707-b6e95c7e-9d78-4fc3-bc47-0690bf121d44.png">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
