### PR TITLE
Fix bug where if there's no calendar in asyncStorage, the dates don't get disabled

### DIFF
--- a/tpp-app/src/home/components/DayComponent.js
+++ b/tpp-app/src/home/components/DayComponent.js
@@ -23,7 +23,7 @@ export const DayComponent = ({ date, state, marking, selectedView, navigation })
         // Basically whatever special value that is attached to the specific key in the Symptoms object
         // i.e. for flow it would be HEAVY/MEDIUM/LIGHT
         // for sleep it will be a number etc.
-        let symptomAttribute = marking.symptoms[viewKey]
+        let symptomAttribute = marking.symptoms ? marking.symptoms[viewKey] : null;
 
         // If disabled
         if (marking.disable) {
@@ -63,8 +63,8 @@ export const DayComponent = ({ date, state, marking, selectedView, navigation })
 
             renderedIcon = createElement(ICON_TYPES[iconName], {
                 style: styles.dayIcon,
-                width: ICON_SIZE.height,
-                height: ICON_SIZE.width,
+                width: ICON_SIZE.width,
+                height: ICON_SIZE.height,
                 fill: textColor
             })
             

--- a/tpp-app/src/home/pages/CalendarScreen.js
+++ b/tpp-app/src/home/pages/CalendarScreen.js
@@ -100,7 +100,7 @@ export default function CalendarScreen ({ route, navigation }) {
                     const yearDataFromStorage = await GETYearData(year);
 
                     // If there's nothing logged for that year, we may still want to disable dates
-                    // Get an empty years
+                    // Get an empty year
                     currentYearData[year] = yearDataFromStorage ? yearDataFromStorage : initializeEmptyYear(year);
 
                     let newCachedYears = {}

--- a/tpp-app/src/home/pages/CalendarScreen.js
+++ b/tpp-app/src/home/pages/CalendarScreen.js
@@ -6,7 +6,7 @@ import Selector, {SelectedIcon} from '../components/Selector';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import { GETYearData } from '../../services/CalendarService';
 import { VIEWS } from '../../services/utils/constants';
-import { getISODate } from '../../services/utils/helpers';
+import {getISODate, initializeEmptyYear} from '../../services/utils/helpers';
 import { useFocusEffect } from '@react-navigation/native';
 
 const sideComponentWidth = 120
@@ -97,7 +97,11 @@ export default function CalendarScreen ({ route, navigation }) {
                 if (cachedYears[year] === undefined) {
 
                     let currentYearData = {}
-                    currentYearData[year] = await GETYearData(year)
+                    const yearDataFromStorage = await GETYearData(year);
+
+                    // If there's nothing logged for that year, we may still want to disable dates
+                    // Get an empty years
+                    currentYearData[year] = yearDataFromStorage ? yearDataFromStorage : initializeEmptyYear(year);
 
                     let newCachedYears = {}
                     newCachedYears[year] = true


### PR DESCRIPTION
- Currently there's a bug where if you skip all steps in onboarding, the dates on the calendar are not getting disabled
- This is because I set a disabled field on calendar dates but if there's no calendar in AsyncStorage there's nothing for me to attach a disabled field to
- So if there's no calendar in AsyncStorage use an empty initialized calendar instead for now