### PR TITLE
Add back button to Confirmation page on Onboarding

### DIFF
--- a/tpp-app/src/onboarding/Confirmation.js
+++ b/tpp-app/src/onboarding/Confirmation.js
@@ -9,6 +9,7 @@ import SleepIcon from "../../ios/tppapp/Images.xcassets/icons/sleep.svg";
 import MoodIcon from "../../ios/tppapp/Images.xcassets/icons/mood.svg";
 import ExerciseIcon from "../../ios/tppapp/Images.xcassets/icons/exercise.svg";
 import CrampsIcon from "../../ios/tppapp/Images.xcassets/icons/cramps.svg";
+import {BackButton} from "../home/components/BackButtonComponent";
 
 export const STACK_SCREENS = {
   GET_STARTED : "Get Started",
@@ -60,6 +61,13 @@ export default function Confirmation ({ route, navigation }) {
 
   return (
     <ImageBackground source={OnboardingBackground} style={styles.container}>
+      <BackButtonContainer>
+        <BackButton title="" onPress={() => {navigation.navigate(STACK_SCREENS.SYMPTOMS_CHOICES, {
+          periodLength: periodLength,
+          periodStart: periodStart,
+          periodEnd: periodEnd
+        })}}/>
+      </BackButtonContainer>
       <PaddyIcon style={{alignSelf: "center"}}/>
       <Text style={styles.bigText}>You're all set!</Text>
       { periodLength && <View>


### PR DESCRIPTION
On the confirmation page, added a back button which leads to Symptoms Choices 
Users asked for this incase they arrive at the confirmation page and want to change the symptoms they want to track