### PR TITLE
bugfix: symptom selection onboarding

### DIFF
--- a/tpp-app/src/onboarding/SymptomsChoices.js
+++ b/tpp-app/src/onboarding/SymptomsChoices.js
@@ -144,7 +144,7 @@ export default function SymptomsChoices({ route, navigation }) {
           <SkipButton
             title="Skip"
             onPress={async () => {
-              POSTSymptomsToTrack(true, false, false, false, false).then(() => {
+              POSTSymptomsToTrack(true, false, false, false, false, false).then(() => {
                 navigation.navigate(STACK_SCREENS.CONFIRMATION, {
                   periodLength: periodLength,
                   periodStart: periodStart,

--- a/tpp-app/src/services/OnboardingService.js
+++ b/tpp-app/src/services/OnboardingService.js
@@ -108,6 +108,15 @@ export const POSTSymptomsToTrack = async (
   ovulation
 ) =>
   new Promise(async (resolve, reject) => {
+    console.log("Tracking values:", {
+      flow,
+      mood,
+      sleep,
+      cramps,
+      exercise,
+      ovulation,
+    });
+    
     try {
       if (
         [flow, mood, sleep, cramps, exercise, ovulation].some((bool) => bool)

--- a/tpp-app/src/services/OnboardingService.js
+++ b/tpp-app/src/services/OnboardingService.js
@@ -108,15 +108,6 @@ export const POSTSymptomsToTrack = async (
   ovulation
 ) =>
   new Promise(async (resolve, reject) => {
-    console.log("Tracking values:", {
-      flow,
-      mood,
-      sleep,
-      cramps,
-      exercise,
-      ovulation,
-    });
-    
     try {
       if (
         [flow, mood, sleep, cramps, exercise, ovulation].some((bool) => bool)


### PR DESCRIPTION
## Description

[Linear Ticket](https://linear.app/the-period-purse/issue/TPPDEV-67/symptom-selection-onboarding-bug)

Added the right parameters to the POSTSymptoms To Track call on the Symptoms Choices page. This should fix the bug in ticket 64 as well. 

Have tested: 
- Skipping entirely. 
- Loggin in arbitrary Symptoms which it now tracks. (With combinations including ovulation and without ovulation. 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
