### PR TITLE
bugfix: ovulation logging

### DIFF
--- a/tpp-app/src/home/pages/LogSymptomsScreen.js
+++ b/tpp-app/src/home/pages/LogSymptomsScreen.js
@@ -47,7 +47,7 @@ const DateArrow = ({ onPress, isRight }) => {
 const symptoms = ["flow", "ovulation", "mood", "sleep", "cramps", "exercise", "notes"]; // order of symptom accordions
 
 export default function LogSymptomsScreen({ navigation, route }) {
-  const initialPrefs = ["notes"];
+  const initialPrefs = ["flow", "notes"];
   const [trackingPrefs, setPrefs] = useState(initialPrefs); // list of symptoms to track, default is always 'notes'
   const [loaded, setLoaded] = useState(false);
 
@@ -62,7 +62,7 @@ export default function LogSymptomsScreen({ navigation, route }) {
         // if tracking that symptom is set to true, append it to trackingPrefs
         if (toTrack) {
           let title = pref[0];
-          let symptom;
+          let symptom = null;
           switch (title) {
             case TRACK_SYMPTOMS.MOOD:
               symptom = "mood";
@@ -79,11 +79,8 @@ export default function LogSymptomsScreen({ navigation, route }) {
             case TRACK_SYMPTOMS.OVULATION:
               symptom = "ovulation";
               break;
-            default:
-              symptom = "flow";
-              break;
           }
-          if (!prefArr.includes(symptom)) prefArr.push(symptom);
+          if (symptom && !prefArr.includes(symptom)) prefArr.push(symptom);
         }
       }
       setPrefs(prefArr);

--- a/tpp-app/src/home/pages/LogSymptomsScreen.js
+++ b/tpp-app/src/home/pages/LogSymptomsScreen.js
@@ -47,7 +47,7 @@ const DateArrow = ({ onPress, isRight }) => {
 const symptoms = ["flow", "ovulation", "mood", "sleep", "cramps", "exercise", "notes"]; // order of symptom accordions
 
 export default function LogSymptomsScreen({ navigation, route }) {
-  const initialPrefs = ["ovulation", "notes"];
+  const initialPrefs = ["notes"];
   const [trackingPrefs, setPrefs] = useState(initialPrefs); // list of symptoms to track, default is always 'notes'
   const [loaded, setLoaded] = useState(false);
 
@@ -75,6 +75,9 @@ export default function LogSymptomsScreen({ navigation, route }) {
               break;
             case TRACK_SYMPTOMS.EXERCISE:
               symptom = "exercise";
+              break;
+            case TRACK_SYMPTOMS.OVULATION:
+              symptom = "ovulation";
               break;
             default:
               symptom = "flow";


### PR DESCRIPTION
## Description

[Linear Ticket](https://linear.app/the-period-purse/issue/TPPDEV-63/symptom-selection-onboarding-bug) 

Removed ovulation logging from the drop-down when not ovulation tracked in settings, and add CASE when ovulation when ovulation is tracked in settings. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
